### PR TITLE
Fix linux builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,18 +68,18 @@ target_link_libraries(SeqBeat VSSynth)
 target_include_directories(SeqBeat PUBLIC include)
 
 # MIDI Example
-file(GLOB_RECURSE MIDI_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} examples/midi/src/*.cpp)
-add_executable(MIDI ${MIDI_SRCS})
-target_link_libraries(MIDI SDL2)
-target_link_libraries(MIDI SDL2main)
-target_link_libraries(MIDI VSSynth)
-target_link_libraries(MIDI midifile)
+#file(GLOB_RECURSE MIDI_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} examples/MIDI/src/*.cpp)
+#add_executable(MIDI ${MIDI_SRCS})
+#target_link_libraries(MIDI SDL2)
+#target_link_libraries(MIDI SDL2main)
+#target_link_libraries(MIDI VSSynth)
+#target_link_libraries(MIDI midifile)
 
-target_include_directories(MIDI PUBLIC include)
+#target_include_directories(MIDI PUBLIC include)
 
 # Set include and link directories
-target_include_directories(MIDI PUBLIC ${INCLUDE_DIR})
-target_link_directories(MIDI PUBLIC ${LIB_DIR})
+#target_include_directories(MIDI PUBLIC ${INCLUDE_DIR})
+#target_link_directories(MIDI PUBLIC ${LIB_DIR})
 
 # Doxygen Docs
 # Look for package, Doxygen

--- a/examples/MIDI/src/MIDIChannel.cpp
+++ b/examples/MIDI/src/MIDIChannel.cpp
@@ -2,6 +2,8 @@
 #include "MIDIEnvelopes.h"
 #include "MIDIPatches.h"
 
+#include <cmath>
+
 #define VELCOCITY_MAX 127.0
 
 MIDIChannel::MIDIChannel(

--- a/examples/MIDI/src/MIDIChannel.h
+++ b/examples/MIDI/src/MIDIChannel.h
@@ -4,7 +4,9 @@
 #include <VSSynth/utils/Envelope.h>
 
 #include <functional>
+#include <stdint.h>
 #include <vector>
+
 
 enum MIDI_EVENT_TYPE
 {

--- a/src/SoundGenerator.cpp
+++ b/src/SoundGenerator.cpp
@@ -1,6 +1,7 @@
 #include <VSSynth/SoundGenerator.h>
 
 #include <algorithm>
+#include <cmath>
 
 // MAX amplitude for a waveform
 // Amplitude must fit in a 16 bit signed integer

--- a/src/generators/Tone.cpp
+++ b/src/generators/Tone.cpp
@@ -1,5 +1,7 @@
 #include <VSSynth/generators/Tone.h>
 
+#include <algorithm>
+
 namespace VSSynth
 {
     namespace Generators


### PR DESCRIPTION
I have to comment out the midi example, because of the missing midifile library
I added the missing includes, so VSSynth compile on linux with GCC10